### PR TITLE
Fully automate dev setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,4 +2,4 @@ FROM gitpod/workspace-full
 
 USER gitpod
 
-RUN pip3 install -U platformio && brew install uncrustify
+RUN pip3 install -U platformio

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+
+USER gitpod
+
+RUN pip3 install -U platformio && brew install uncrustify

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,8 +6,7 @@ tasks:
 
 vscode:
   extensions:
-    - ms-vscode.cpptools@0.26.3:u3GsZ5PK12Ddr79vh4TWgQ==
-    - eamodio.gitlens@10.2.1:e0IYyp0efFqVsrZwsIe8CA==
-    - LaurentTreguier.uncrustify@2.18.0:/k8Osjj/XSuz09F+pEu7wg==
-    - Atishay-Jain.All-Autocomplete@0.0.23:fbZNfSpnd8XkAHGfAPS2rA==
-    - 2gua.rainbow-brackets@0.0.6:Tbu8dTz0i+/bgcKQTQ5b8g==
+    - ms-vscode.cpptools@1.1.2
+    - platformio.platformio-ide@2.2.1
+    - eamodio.gitlens@11.0.6
+    - 2gua.rainbow-brackets@0.0.6

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,6 @@ tasks:
 
 vscode:
   extensions:
-    - ms-vscode.cpptools@1.1.2
-    - platformio.platformio-ide@2.2.1
-    - eamodio.gitlens@11.0.6
-    - 2gua.rainbow-brackets@0.0.6
+    - ms-vscode.cpptools@1.1.2:TF4Nx06hqY/irDWq5PrlxQ==
+    - eamodio.gitlens@10.2.1:e0IYyp0efFqVsrZwsIe8CA==
+    - 2gua.rainbow-brackets@0.0.6:Tbu8dTz0i+/bgcKQTQ5b8g==

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,13 @@
+image:
+  file: .gitpod.Dockerfile
+
+tasks:
+  - command: platformio run -e d1_mini
+
+vscode:
+  extensions:
+    - ms-vscode.cpptools@0.26.3:u3GsZ5PK12Ddr79vh4TWgQ==
+    - eamodio.gitlens@10.2.1:e0IYyp0efFqVsrZwsIe8CA==
+    - LaurentTreguier.uncrustify@2.18.0:/k8Osjj/XSuz09F+pEu7wg==
+    - Atishay-Jain.All-Autocomplete@0.0.23:fbZNfSpnd8XkAHGfAPS2rA==
+    - 2gua.rainbow-brackets@0.0.6:Tbu8dTz0i+/bgcKQTQ5b8g==

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/pfeerick/ISS-Notifier)
+
 # ISS Notifier
 Neopixel notifier for when the ISS goes overhead
 


### PR DESCRIPTION
This commit implements a fully-automated development setup using Gitpod.io, an
online IDE for GitHub and GitLab that enables Dev-Environments-As-Code.
This makes it easy for anyone to get a ready-to-code workspace for any branch,
issue or pull request almost instantly with a single click.